### PR TITLE
Rami's Recs

### DIFF
--- a/src/main/java/frc/Main.java
+++ b/src/main/java/frc/Main.java
@@ -191,7 +191,7 @@ public final class Main extends TimedRobot {
             DriverStation.silenceJoystickConnectionWarning(true);
         }
         // TODO: re-enable vision once the jitter is solved.
-        // new Nt().register(drivetrain);
+        new Nt().register(drivetrain);
 
         configAutos();
         configButtonBindings();

--- a/src/main/java/frc/system/Swerve.java
+++ b/src/main/java/frc/system/Swerve.java
@@ -231,9 +231,11 @@ public class Swerve extends SwerveDrivetrain implements LoggedSubsystems, Consum
 
     // ---------- Vision ----------
     public void accept(Measurement t) {
-        if (hasPose) {
+        if (hasPose) {                                              // Just double checking is this just so that the first time we run this we set seedFieldRelative?
+                                                                    // we absolutely need to confirm that we're within 1 meter of where we think we are before we add these values to the filter...
             if (t.stdDev() != null) {
-                addVisionMeasurement(t.pose().toPose2d(), t.timestamp(), t.stdDev());
+                addVisionMeasurement(t.pose().toPose2d(), t.timestamp(), t.stdDev());               // Let's make sure this isn't null.
+                                                                                                    // https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/mechanisms/swerve/SwerveDrivetrain.html#addVisionMeasurement(edu.wpi.first.math.geometry.Pose2d,double) This says that we need to dump those values and this is for teams that aren't running as crazy high FPS as we are...
             } else {
                 addVisionMeasurement(t.pose().toPose2d(), t.timestamp());
             }

--- a/src/main/java/frc/system/vision/Nt.java
+++ b/src/main/java/frc/system/vision/Nt.java
@@ -26,7 +26,7 @@ public class Nt implements Vision {
 	final AprilTagFieldLayout tags = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
 
 	@Override
-	public void register(Consumer<Measurement> measurement) {
+	public void register(Consumer<Measurement> drivetrain) {
 		NetworkTableInstance nt = NetworkTableInstance.getDefault();
 
 		NetworkTable table = nt.getTable("Subsystems");
@@ -82,11 +82,11 @@ public class Nt implements Vision {
 					if (n != 0) {
 
 						cached.pose = new Pose3d(pX / n, pY / n, pZ / n, new Rotation3d(rX / n, rY / n, rZ / n));
-						cached.timestamp = event.valueData.value.getTime();
-						// TODO: calculate standard deviations of pose measurement.
+						cached.timestamp = event.valueData.value.getTime();  // Timer.getFPGATimestamp() (I Think this needs to be FPGA Timestamp to make sense ref: https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/mechanisms/swerve/SwerveDrivetrain.html addVisionMeasurement )
+						// TODO: calculate standard deviations of pose drivetrain. This TODO needs to happen as we're getting significantly more measurements than the avg FRC team which is part of why the Kalman filter is freaking out... 
 						cached.stdDev = null;
 
-						measurement.accept(cached);
+						drivetrain.accept(cached);
 
 						ntOut.set(cached.pose);
 					}


### PR DESCRIPTION
### Main Problems:

- No SD based on rolling data currently exists.
- We don't dump Aril tag visions that are > 1m from where we think we are...

### How these problems are causing our issues:

- Since the distance is what jitters the most distance from April tag will put the robot significantly further away on the field therefore when we dump >1m vision data we get rid of most of the bad reads...
- Default Kalman filter assumes we're getting ~10 FPS vision data and only when the robot is stopped since it is set up for most teams. We're feeding it ~50 fps (I think I don't remember actually what the settings are) and we can see the April tags WAY more often because of the global shutter (like incredibly noticeable from my testing). Therefore the default SD is wayyy off for our use case... and we're feeding enough data that it's doubting the odometry.
- The Gyro is really accurate (specially at the start) we should trust it over our vision data and the vision data should only be used when we're extremely confident it's true.

@Phrogz, please let me know if this makes sense or I am completely off base here... 